### PR TITLE
BugFix Agent `HostInterface` param is optional.

### DIFF
--- a/templates/zabbix_agent.j2
+++ b/templates/zabbix_agent.j2
@@ -7,7 +7,9 @@ Server={{ zbx_agent_server }}
 ServerActive={{ zbx_agent_server_active }}
 HostnameItem=system.hostname
 HostMetadata={{ zbx_agent_hostmetadata }}
+{% if zbx_agent_hostinterface is defined and zbx_agent_hostinterface|length %}
 HostInterface={{ zbx_agent_hostinterface }}
+{% endif %}
 TLSConnect=psk
 TLSAccept=psk
 TLSPSKIdentity={{ zbx_agent_pskid }}


### PR DESCRIPTION
Fix an issue whereby `HostInterface` would be empty if `zbx_agent_hostinterface` Ansible variable isn't defined or is empty. As per the Zabbix documentation this is optional, however setting to an empty value will break features like auto-registration.  

Check param is set & has a value, if so, write to `zabbix_agent.conf`

Tested on Ubuntu 20.04, Ubuntu 22.04, Debian 11.