### PR TITLE
Implemented proper optionality to some variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ License
 
 GPL-3.0-only
 
+Contributing
+------------
+
+To contribute to the project please fork it, make your changes then open a pull request. Your changes will be considered for merging provided it passes all CI tests. If any changes are required before merging these will be discussed in the pull request discussion thread.
+
 Author Information
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Ansible Role - Zabbix Agent [![CI](https://github.com/dandyrow/ansible-role-zabbix-agent/actions/workflows/CI.yml/badge.svg?branch=master)](https://github.com/dandyrow/ansible-role-zabbix-agent/actions/workflows/CI.yml)
 =========
 
-An Ansible role that installs and configures the zabbix agent on Linux.
+An Ansible role that installs and configures the zabbix agent on Linux. Supports setting up agent for use with autoregistration and psk encryption.
 
 Install from Ansible Galaxy using this command: `ansible-galaxy install dandyrow.zabbix_agent`
 
@@ -10,23 +10,33 @@ View Ansible Galaxy page [here](https://galaxy.ansible.com/dandyrow/zabbix_agent
 Role Variables
 --------------
 
-Variables listed below used to configure the Zabbix agent alongside default value, see `default/main.yml`. For more detail on these values see the Zabbix documentation [here](https://www.zabbix.com/documentation/current/en/manual/appendix/config/zabbix_agentd):
+Variables listed below used to configure the Zabbix agent. For more detail on these values see the Zabbix documentation [here](https://www.zabbix.com/documentation/current/en/manual/appendix/config/zabbix_agentd).
 
-`zbx_dir: /etc/zabbix` - Change to the directory where Zabbix conf file is located.
+### Required Variables
 
-`zbx_version: "6.2"` - Change to desired version of Zabbix agent to install. Used in `zabbix_repo` role to install corresponding repository to version of Zabbix to install.
+These variables are required for the role to run. The default value listed is set in `defaults/main.yml`.
 
-`zbx_agent_server: "127.0.0.1"` - The IP address(s) and/or DNS name(s) of the Zabbix server or proxy which should passively monitor this agent.
+`zbx_dir: [Default: /etc/zabbix]` - Change to the directory where Zabbix conf file is located.
 
-`zbx_agent_server_active: "127.0.0.1"` - The IP address(s) and/or DNS name(s) of the Zabbix server or proxy which should actively monitor this agent.
+`zbx_version: [Default: "6.2"]` - Change to desired version of Zabbix agent to install.
 
-`zbx_agent_hostmetadata: ""` - Defines the host metadata used for during autoregistration to apply templates (optional).
+`zbx_agent_server: [Default: "127.0.0.1"]` - The IP address(s) and/or DNS name(s) of the Zabbix server or proxy which should passively monitor this agent.
 
-`zbx_agent_hostinterface: ""` - Defines the host interface used during autoregistration to setup passive checks (optional).
+`zbx_agent_server_active: [Default: "127.0.0.1"]` - The IP address(s) and/or DNS name(s) of the Zabbix server or proxy which should actively monitor this agent.
 
-`zbx_agent_pskid: "example"` - Sets the PSK ID for the agent. Default should not be used in production.
+### Optional Variables
 
-`zbx_agent_psk: "7c1d185a11403fcb315ef3509d064131c515ec7b6113b3e1a8484b60b6d5dca0"` - Sets the PSK which will be stored in the file `/etc/zabbix/zabbix_agent.psk` on the host. The value of this must be longer than 32 characters and contain only letters and numbers. Default should not be used in production.
+These variables can optionally be set to configure the Zabbix agent for your usecase.
+
+`zbx_agent_hostname:` - Defines the hostname which the Zabbix agent will use for the host.
+
+`zbx_agent_hostmetadata:` - Defines the host metadata used for during autoregistration to apply templates (optional).
+
+`zbx_agent_hostinterface:` - Defines the host interface used during autoregistration to setup passive checks (optional).
+
+`zbx_agent_pskid:` - Sets the PSK ID for the agent.
+
+`zbx_agent_psk:` - Sets the PSK which will be stored in the file `{zbx_dir}/zabbix_agent.psk` on the host. The value of this must be longer than 32 characters and contain only letters and numbers otherwise the agent will fail to start.
 
 Supported Platforms
 -------------------
@@ -47,7 +57,7 @@ Example Playbook
 ```yaml
 - hosts: all
   roles:
-    - dandyrow.zabbix_agent
+    - role: dandyrow.zabbix_agent
 ```
 
 License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,3 @@ zbx_version: "6.2"
 
 zbx_agent_server: "127.0.0.1"
 zbx_agent_server_active: "127.0.0.1"
-zbx_agent_hostmetadata: ""
-zbx_agent_hostinterface: ""
-zbx_agent_pskid: "example"
-zbx_agent_psk: "7c1d185a11403fcb315ef3509d064131c515ec7b6113b3e1a8484b60b6d5dca0"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,6 +1,4 @@
 ---
-# This is an example playbook to execute Ansible tests.
-
 - name: Verify
   hosts: all
   gather_facts: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,16 +5,6 @@
 
 - ansible.builtin.include_tasks: "{{ ansible_os_family }}.yml"
 
-- name: Copy PSK file
-  ansible.builtin.template:
-   src: "{{ role_path }}/templates/psk.j2"
-   dest: "{{ zbx_dir }}/zabbix_agent.psk"
-   owner: "{{ zbx_usr }}"
-   group: "{{ zbx_usr }}"
-   mode: 0400
-  notify: 
-    - Restart zabbix-agent
-
 - name: Remove hostname definition in conf file
   ansible.builtin.lineinfile:
     path: "{{ zbx_dir }}/zabbix_agentd.conf"
@@ -32,21 +22,32 @@
 
 - name: Include config parameters
   ansible.builtin.lineinfile:
-   path: "{{ zbx_dir }}/zabbix_agentd.conf"
-   regexp: ^(Include=)$
-   insertafter: "# Include="
-   line: Include={{ zbx_dir }}/zabbix_agentd.d/*.conf
-   backrefs: true
-   state: present
+    path: "{{ zbx_dir }}/zabbix_agentd.conf"
+    regexp: ^(Include=)$
+    insertafter: "# Include="
+    line: Include={{ zbx_dir }}/zabbix_agentd.d/*.conf
+    backrefs: true
+    state: present
 
 - name: Configure Zabbix agent
   ansible.builtin.template:
     owner: root
     group: root
     mode: 0644
-    src: '{{ role_path }}/templates/zabbix_agent.j2'
+    src: "{{ role_path }}/templates/zabbix_agent.j2"
     dest: "{{ zbx_dir }}/zabbix_agentd.d/agent.conf"
-  notify: 
+  notify:
+    - Restart zabbix-agent
+
+- name: Copy PSK file
+  ansible.builtin.template:
+    src: "{{ role_path }}/templates/psk.j2"
+    dest: "{{ zbx_dir }}/zabbix_agent.psk"
+    owner: "{{ zbx_usr }}"
+    group: "{{ zbx_usr }}"
+    mode: 0400
+  when: zbx_agent_psk | defined
+  notify:
     - Restart zabbix-agent
 
 - name: Start and enable Zabbix agent service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,7 +46,7 @@
     owner: "{{ zbx_usr }}"
     group: "{{ zbx_usr }}"
     mode: 0400
-  when: zbx_agent_psk | defined
+  when: zbx_agent_psk is defined
   notify:
     - Restart zabbix-agent
 

--- a/templates/zabbix_agent.j2
+++ b/templates/zabbix_agent.j2
@@ -1,16 +1,30 @@
+# {{ ansible_managed }}
 LogType=file
 LogFile=/var/log/zabbix/zabbix_agentd.log
 LogFileSize=50
+
 AllowKey=system.run[*]
 LogRemoteCommands=1
+
 Server={{ zbx_agent_server }}
 ServerActive={{ zbx_agent_server_active }}
+
+{% if zbx_agent_hostname is defined %}
+Hostname={{ zbx_agent_hostname }}
+{% else %}
 HostnameItem=system.hostname
+{% endif %}
+
+{% if zbx_agent_hostmetadata is defined %}
 HostMetadata={{ zbx_agent_hostmetadata }}
-{% if zbx_agent_hostinterface is defined and zbx_agent_hostinterface|length %}
+{% endif %}
+{% if zbx_agent_hostinterface is defined %}
 HostInterface={{ zbx_agent_hostinterface }}
 {% endif %}
+
+{% if zbx_agent_pskid is defined and zbx_agent_psk is defined %}
 TLSConnect=psk
 TLSAccept=psk
 TLSPSKIdentity={{ zbx_agent_pskid }}
 TLSPSKFile={{ zbx_dir }}/zabbix_agent.psk
+{% endif %}


### PR DESCRIPTION
Optional variables don't have to be defined for the proper execution of the role.

Added the ability to set hostname of agent and leave it at default unencrypted connection.